### PR TITLE
Use Content-Encoding to identify if data is binary

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -549,9 +549,9 @@ class LambdaHandler:
                         zappa_returndict.setdefault('statusDescription', response.status)
 
                     if response.data:
-                        if settings.BINARY_SUPPORT and \
-                                not response.mimetype.startswith("text/") \
-                                and response.mimetype != "application/json":
+                        content_encoding = response.headers.get("Content-Encoding", None)
+                        binary_encodings = ("gzip", "compress", "deflate", "br")
+                        if settings.BINARY_SUPPORT and content_encoding in binary_encodings:
                             zappa_returndict['body'] = base64.b64encode(response.data).decode('utf-8')
                             zappa_returndict["isBase64Encoded"] = True
                         else:


### PR DESCRIPTION
When using _whitenoise_ for caching, which provides compression, binary types may include mimetypes, "text/", "application/json":

- response.mimetype.startswith("text/")
- response.mimetype == "application/json"

Assuming that Content-Encoding will be set (as whitenoise apparently does) this allows compression to be applied by the application for "text/" and "application/json".

About Content-Encoding:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

